### PR TITLE
fix to work on ERPNext v15

### DIFF
--- a/qrcode_gen/hooks.py
+++ b/qrcode_gen/hooks.py
@@ -173,8 +173,8 @@ user_data_fields = [
 # 	"qrcode_gen.auth.validate"
 # ]
 
-jenv = {
+jinja = {
 	"methods": [
-		"gen_qrcode:qrcode_gen.qrcode.gen_qrcode"
+		"qrcode_gen.qrcode.gen_qrcode"
 	]
 }


### PR DESCRIPTION
ERPNext changed the way jinja functions are registered. This change resolves the issue to make it compatible with ERPNext 15.0+